### PR TITLE
Removing ETH pin reservation from regular ESP32 for ESP32S3

### DIFF
--- a/wled00/cfg.cpp
+++ b/wled00/cfg.cpp
@@ -737,7 +737,7 @@ void serializeConfig() {
   wifi[F("sleep")] = !noWifiSleep;
   wifi[F("phy")] = force802_3g;
 
-  #ifdef WLED_USE_ETHERNET
+  #if defined(WLED_USE_ETHERNET) && !defined(CONFIG_IDF_TARGET_ESP32S3)
   JsonObject ethernet = doc.createNestedObject("eth");
   ethernet["type"] = ethernetType;
   if (ethernetType != WLED_ETH_NONE && ethernetType < WLED_NUM_ETH_TYPES) {
@@ -746,7 +746,7 @@ void serializeConfig() {
     if (ethernetBoards[ethernetType].eth_power>=0)     pins.add(ethernetBoards[ethernetType].eth_power);
     if (ethernetBoards[ethernetType].eth_mdc>=0)       pins.add(ethernetBoards[ethernetType].eth_mdc);
     if (ethernetBoards[ethernetType].eth_mdio>=0)      pins.add(ethernetBoards[ethernetType].eth_mdio);
-    #ifndef CONFIG_IDF_TARGET_ESP32S3
+//    #ifndef CONFIG_IDF_TARGET_ESP32S3
     switch (ethernetBoards[ethernetType].eth_clk_mode) {
       case ETH_CLOCK_GPIO0_IN:
       case ETH_CLOCK_GPIO0_OUT:
@@ -759,7 +759,7 @@ void serializeConfig() {
         pins.add(17);
         break;
     }
-    #endif
+//    #endif
   }
   #endif
 

--- a/wled00/network.cpp
+++ b/wled00/network.cpp
@@ -6,17 +6,19 @@
 #ifdef WLED_USE_ETHERNET
 #pragma message "Ethernet support enabled"
 
-// The following six pins are neither configurable nor
-// can they be re-assigned through IOMUX / GPIO matrix.
-// See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.1.html#ip101gri-phy-interface
-const managed_pin_type esp32_nonconfigurable_ethernet_pins[WLED_ETH_RSVD_PINS_COUNT] = {
-    { 21, true  }, // RMII EMAC TX EN  == When high, clocks the data on TXD0 and TXD1 to transmitter
-    { 19, true  }, // RMII EMAC TXD0   == First bit of transmitted data
-    { 22, true  }, // RMII EMAC TXD1   == Second bit of transmitted data
-    { 25, false }, // RMII EMAC RXD0   == First bit of received data
-    { 26, false }, // RMII EMAC RXD1   == Second bit of received data
-    { 27, true  }, // RMII EMAC CRS_DV == Carrier Sense and RX Data Valid
-};
+#ifndef CONFIG_IDF_TARGET_ESP32S3
+  // The following six pins are neither configurable nor
+  // can they be re-assigned through IOMUX / GPIO matrix.
+  // See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit-v1.1.html#ip101gri-phy-interface
+  const managed_pin_type esp32_nonconfigurable_ethernet_pins[WLED_ETH_RSVD_PINS_COUNT] = {
+      { 21, true  }, // RMII EMAC TX EN  == When high, clocks the data on TXD0 and TXD1 to transmitter
+      { 19, true  }, // RMII EMAC TXD0   == First bit of transmitted data
+      { 22, true  }, // RMII EMAC TXD1   == Second bit of transmitted data
+      { 25, false }, // RMII EMAC RXD0   == First bit of received data
+      { 26, false }, // RMII EMAC RXD1   == Second bit of received data
+      { 27, true  }, // RMII EMAC CRS_DV == Carrier Sense and RX Data Valid
+  };
+#endif
 
 const ethernet_settings ethernetBoards[] = {
   // None

--- a/wled00/wled_ethernet.h
+++ b/wled00/wled_ethernet.h
@@ -5,33 +5,34 @@
 
 #ifdef WLED_USE_ETHERNET
 
-// For ESP32, the remaining five pins are at least somewhat configurable.
-// eth_address  is in range [0..31], indicates which PHY (MAC?) address should be allocated to the interface
-// eth_power    is an output GPIO pin used to enable/disable the ethernet port (and/or external oscillator)
-// eth_mdc      is an output GPIO pin used to provide the clock for the management data
-// eth_mdio     is an input/output GPIO pin used to transfer management data
-// eth_type     is the physical ethernet module's type (ETH_PHY_LAN8720, ETH_PHY_TLK110)
-// eth_clk_mode defines the GPIO pin and GPIO mode for the clock signal
-//              However, there are really only four configurable options on ESP32:
-//              ETH_CLOCK_GPIO0_IN    == External oscillator, clock input  via GPIO0
-//              ETH_CLOCK_GPIO0_OUT   == ESP32 provides 50MHz clock output via GPIO0
-//              ETH_CLOCK_GPIO16_OUT  == ESP32 provides 50MHz clock output via GPIO16
-//              ETH_CLOCK_GPIO17_OUT  == ESP32 provides 50MHz clock output via GPIO17
-typedef struct EthernetSettings {
-  uint8_t        eth_address;
-  int            eth_power;
-  int            eth_mdc;
-  int            eth_mdio;
-  eth_phy_type_t eth_type;
+  // For ESP32, the remaining five pins are at least somewhat configurable.
+  // eth_address  is in range [0..31], indicates which PHY (MAC?) address should be allocated to the interface
+  // eth_power    is an output GPIO pin used to enable/disable the ethernet port (and/or external oscillator)
+  // eth_mdc      is an output GPIO pin used to provide the clock for the management data
+  // eth_mdio     is an input/output GPIO pin used to transfer management data
+  // eth_type     is the physical ethernet module's type (ETH_PHY_LAN8720, ETH_PHY_TLK110)
+  // eth_clk_mode defines the GPIO pin and GPIO mode for the clock signal
+  //              However, there are really only four configurable options on ESP32:
+  //              ETH_CLOCK_GPIO0_IN    == External oscillator, clock input  via GPIO0
+  //              ETH_CLOCK_GPIO0_OUT   == ESP32 provides 50MHz clock output via GPIO0
+  //              ETH_CLOCK_GPIO16_OUT  == ESP32 provides 50MHz clock output via GPIO16
+  //              ETH_CLOCK_GPIO17_OUT  == ESP32 provides 50MHz clock output via GPIO17
+  typedef struct EthernetSettings {
+    uint8_t        eth_address;
+    int            eth_power;
+    int            eth_mdc;
+    int            eth_mdio;
+    eth_phy_type_t eth_type;
+    #ifndef CONFIG_IDF_TARGET_ESP32S3
+      eth_clock_mode_t eth_clk_mode;
+    #endif
+  } ethernet_settings;
+
+  extern const ethernet_settings ethernetBoards[];
   #ifndef CONFIG_IDF_TARGET_ESP32S3
-  eth_clock_mode_t eth_clk_mode;
+    #define WLED_ETH_RSVD_PINS_COUNT 6
+    extern const managed_pin_type esp32_nonconfigurable_ethernet_pins[WLED_ETH_RSVD_PINS_COUNT];
   #endif
-} ethernet_settings;
-
-extern const ethernet_settings ethernetBoards[];
-
-#define WLED_ETH_RSVD_PINS_COUNT 6
-extern const managed_pin_type esp32_nonconfigurable_ethernet_pins[WLED_ETH_RSVD_PINS_COUNT];
 #endif
 
 #endif

--- a/wled00/xml.cpp
+++ b/wled00/xml.cpp
@@ -239,13 +239,13 @@ void appendGPIOinfo() {
     #endif
   #endif
 
-  #ifdef WLED_USE_ETHERNET
+  #if defined(WLED_USE_ETHERNET) && !defined(CONFIG_IDF_TARGET_ESP32S3)
   if (ethernetType != WLED_ETH_NONE && ethernetType < WLED_NUM_ETH_TYPES) {
     for (uint8_t p=0; p<WLED_ETH_RSVD_PINS_COUNT; p++) { oappend(","); oappend(itoa(esp32_nonconfigurable_ethernet_pins[p].pin,nS,10)); }
     if (ethernetBoards[ethernetType].eth_power>=0)     { oappend(","); oappend(itoa(ethernetBoards[ethernetType].eth_power,nS,10)); }
     if (ethernetBoards[ethernetType].eth_mdc>=0)       { oappend(","); oappend(itoa(ethernetBoards[ethernetType].eth_mdc,nS,10)); }
     if (ethernetBoards[ethernetType].eth_mdio>=0)      { oappend(","); oappend(itoa(ethernetBoards[ethernetType].eth_mdio,nS,10)); }
-    #ifndef CONFIG_IDF_TARGET_ESP32S3
+    //#ifndef CONFIG_IDF_TARGET_ESP32S3
     switch (ethernetBoards[ethernetType].eth_clk_mode) {
       case ETH_CLOCK_GPIO0_IN:
       case ETH_CLOCK_GPIO0_OUT:
@@ -258,7 +258,7 @@ void appendGPIOinfo() {
         oappend(SET_F(",17"));
         break;
     }
-    #endif
+    //#endif
   }
   #endif
 


### PR DESCRIPTION
Removing ETH pin reservation from regular ESP32 for ESP32S3
Reserved pins are not visible in the serial terminal when connecting to ESP32S3.
They are only visible in the GUI and cannot be used for anything else, even during pre-compile configuration.